### PR TITLE
Enable rust-2018-idioms and rust-2021-compatibility lint groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ check:
 .PHONY: lint
 lint: $(SRC)
 	rustfmt --check $(SRC)
-	cargo clippy --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
+	cargo clippy --all-targets --all-features -- -D warnings -D rust-2018-idioms -D rust-2021-compatibility -A clippy::upper-case-acronyms
 
 .PHONY: fmt
 fmt:

--- a/exe/tests/extract.rs
+++ b/exe/tests/extract.rs
@@ -1,7 +1,4 @@
 use std::ffi::OsStr;
-
-extern crate dir_diff;
-
 use tempfile::tempdir;
 
 // see https://github.com/rust-lang/rust/issues/46379#issuecomment-548787629

--- a/format/src/error.rs
+++ b/format/src/error.rs
@@ -1,6 +1,3 @@
-extern crate serde_cbor;
-extern crate serde_json;
-
 use std::backtrace::Backtrace;
 use std::io;
 use std::os::raw::c_int;

--- a/format/src/types.rs
+++ b/format/src/types.rs
@@ -1,9 +1,6 @@
-extern crate serde_cbor;
-extern crate xattr;
-use std::collections::BTreeMap;
-
 use memmap2::{Mmap, MmapOptions};
 use std::backtrace::Backtrace;
+use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::ffi::OsString;
 use std::fmt;
@@ -712,7 +709,7 @@ impl Digest {
 }
 
 impl fmt::Display for Digest {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
     }
 }

--- a/oci/src/index.rs
+++ b/oci/src/index.rs
@@ -5,8 +5,6 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-extern crate serde_json;
-
 use crate::descriptor::Descriptor;
 use format::{Result, WireFormatError};
 

--- a/oci/src/lib.rs
+++ b/oci/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate hex;
-
 use fsverity_helpers::check_fs_verity;
 use std::any::Any;
 use std::backtrace::Backtrace;

--- a/reader/src/fuse.rs
+++ b/reader/src/fuse.rs
@@ -205,7 +205,7 @@ impl Drop for Fuse {
 impl Filesystem for Fuse {
     fn init(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _config: &mut KernelConfig,
     ) -> std::result::Result<(), c_int> {
         if let Some(init_notify) = self.init_notify.take() {
@@ -254,12 +254,12 @@ impl Filesystem for Fuse {
     }
 
     fn destroy(&mut self) {}
-    fn forget(&mut self, _req: &Request, _ino: u64, _nlookup: u64) {}
+    fn forget(&mut self, _req: &Request<'_>, _ino: u64, _nlookup: u64) {}
 
     // puzzlefs is readonly, so we can ignore a bunch of requests
     fn setattr(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _mode: Option<u32>,
         _uid: Option<u32>,
@@ -281,7 +281,7 @@ impl Filesystem for Fuse {
 
     fn mknod(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _parent: u64,
         _name: &OsStr,
         _mode: u32,
@@ -295,7 +295,7 @@ impl Filesystem for Fuse {
 
     fn mkdir(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _parent: u64,
         _name: &OsStr,
         _mode: u32,
@@ -306,19 +306,25 @@ impl Filesystem for Fuse {
         reply.error(Errno::EROFS as i32)
     }
 
-    fn unlink(&mut self, _req: &Request, _parent: u64, _name: &OsStr, reply: fuser::ReplyEmpty) {
+    fn unlink(
+        &mut self,
+        _req: &Request<'_>,
+        _parent: u64,
+        _name: &OsStr,
+        reply: fuser::ReplyEmpty,
+    ) {
         debug!("unlink not supported!");
         reply.error(Errno::EROFS as i32)
     }
 
-    fn rmdir(&mut self, _req: &Request, _parent: u64, _name: &OsStr, reply: fuser::ReplyEmpty) {
+    fn rmdir(&mut self, _req: &Request<'_>, _parent: u64, _name: &OsStr, reply: fuser::ReplyEmpty) {
         debug!("rmdir not supported!");
         reply.error(Errno::EROFS as i32)
     }
 
     fn symlink(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _parent: u64,
         _name: &OsStr,
         _link: &Path,
@@ -330,7 +336,7 @@ impl Filesystem for Fuse {
 
     fn rename(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _parent: u64,
         _name: &OsStr,
         _newparent: u64,
@@ -344,7 +350,7 @@ impl Filesystem for Fuse {
 
     fn link(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _newparent: u64,
         _newname: &OsStr,
@@ -356,7 +362,7 @@ impl Filesystem for Fuse {
 
     fn write(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _offset: i64,
@@ -372,7 +378,7 @@ impl Filesystem for Fuse {
 
     fn flush(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _lock_owner: u64,
@@ -384,7 +390,7 @@ impl Filesystem for Fuse {
 
     fn fsync(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _datasync: bool,
@@ -396,7 +402,7 @@ impl Filesystem for Fuse {
 
     fn fsyncdir(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _datasync: bool,
@@ -408,7 +414,7 @@ impl Filesystem for Fuse {
 
     fn setxattr(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _name: &OsStr,
         _value: &[u8],
@@ -419,14 +425,20 @@ impl Filesystem for Fuse {
         reply.error(Errno::EROFS as i32)
     }
 
-    fn removexattr(&mut self, _req: &Request, _ino: u64, _name: &OsStr, reply: fuser::ReplyEmpty) {
+    fn removexattr(
+        &mut self,
+        _req: &Request<'_>,
+        _ino: u64,
+        _name: &OsStr,
+        reply: fuser::ReplyEmpty,
+    ) {
         debug!("removexattr not supported!");
         reply.error(Errno::EROFS as i32)
     }
 
     fn create(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _parent: u64,
         _name: &OsStr,
         _mode: u32,
@@ -440,7 +452,7 @@ impl Filesystem for Fuse {
 
     fn getlk(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _lock_owner: u64,
@@ -456,7 +468,7 @@ impl Filesystem for Fuse {
 
     fn setlk(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _lock_owner: u64,
@@ -471,7 +483,7 @@ impl Filesystem for Fuse {
         reply.error(Errno::EROFS as i32)
     }
 
-    fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
         match self._lookup(parent, name) {
             Ok(attr) => {
                 // http://libfuse.github.io/doxygen/structfuse__entry__param.html
@@ -486,7 +498,7 @@ impl Filesystem for Fuse {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, reply: fuser::ReplyAttr) {
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, reply: fuser::ReplyAttr) {
         match self._getattr(ino) {
             Ok(attr) => {
                 // http://libfuse.github.io/doxygen/structfuse__entry__param.html
@@ -500,7 +512,7 @@ impl Filesystem for Fuse {
         }
     }
 
-    fn readlink(&mut self, _req: &Request, ino: u64, reply: ReplyData) {
+    fn readlink(&mut self, _req: &Request<'_>, ino: u64, reply: ReplyData) {
         match self._readlink(ino) {
             Ok(symlink) => reply.data(symlink.as_bytes()),
             Err(e) => {
@@ -510,13 +522,13 @@ impl Filesystem for Fuse {
         }
     }
 
-    fn open(&mut self, _req: &Request, _ino: u64, flags: i32, reply: ReplyOpen) {
+    fn open(&mut self, _req: &Request<'_>, _ino: u64, flags: i32, reply: ReplyOpen) {
         self._open(flags, reply)
     }
 
     fn read(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         ino: u64,
         _fh: u64,
         offset: i64,
@@ -538,7 +550,7 @@ impl Filesystem for Fuse {
 
     fn release(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _flags: i32,
@@ -550,13 +562,13 @@ impl Filesystem for Fuse {
         reply.ok()
     }
 
-    fn opendir(&mut self, _req: &Request, _ino: u64, flags: i32, reply: ReplyOpen) {
+    fn opendir(&mut self, _req: &Request<'_>, _ino: u64, flags: i32, reply: ReplyOpen) {
         self._open(flags, reply)
     }
 
     fn readdir(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         ino: u64,
         _fh: u64,
         offset: i64,
@@ -573,7 +585,7 @@ impl Filesystem for Fuse {
 
     fn releasedir(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _fh: u64,
         _flags: i32,
@@ -583,7 +595,7 @@ impl Filesystem for Fuse {
         reply.ok()
     }
 
-    fn statfs(&mut self, _req: &Request, _ino: u64, reply: fuser::ReplyStatfs) {
+    fn statfs(&mut self, _req: &Request<'_>, _ino: u64, reply: fuser::ReplyStatfs) {
         reply.statfs(
             0,   // blocks
             0,   // bfree
@@ -598,7 +610,7 @@ impl Filesystem for Fuse {
 
     fn getxattr(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         ino: u64,
         name: &OsStr,
         size: u32,
@@ -625,7 +637,7 @@ impl Filesystem for Fuse {
         }
     }
 
-    fn listxattr(&mut self, _req: &Request, ino: u64, size: u32, reply: fuser::ReplyXattr) {
+    fn listxattr(&mut self, _req: &Request<'_>, ino: u64, size: u32, reply: fuser::ReplyXattr) {
         match self._listxattr(ino) {
             Ok(xattr) => {
                 let xattr_len: u32 = xattr
@@ -647,13 +659,13 @@ impl Filesystem for Fuse {
         }
     }
 
-    fn access(&mut self, _req: &Request, _ino: u64, _mask: i32, reply: fuser::ReplyEmpty) {
+    fn access(&mut self, _req: &Request<'_>, _ino: u64, _mask: i32, reply: fuser::ReplyEmpty) {
         reply.ok()
     }
 
     fn bmap(
         &mut self,
-        _req: &Request,
+        _req: &Request<'_>,
         _ino: u64,
         _blocksize: u32,
         _idx: u64,
@@ -669,7 +681,7 @@ mod tests {
     use std::io;
     use std::path::Path;
 
-    extern crate hex;
+    use hex;
     use sha2::{Digest, Sha256};
     use tempfile::tempdir;
 

--- a/reader/src/puzzlefs.rs
+++ b/reader/src/puzzlefs.rs
@@ -212,7 +212,7 @@ impl PuzzleFS {
 
     // lookup performs a path-based lookup in this puzzlefs
     pub fn lookup(&mut self, p: &Path) -> Result<Option<Inode>> {
-        let components = p.components().collect::<Vec<Component>>();
+        let components = p.components().collect::<Vec<Component<'_>>>();
         if !matches!(components[0], Component::RootDir) {
             return Err(WireFormatError::from_errno(Errno::EINVAL));
         }

--- a/reader/src/walk.rs
+++ b/reader/src/walk.rs
@@ -72,8 +72,6 @@ impl DirEntry {
 
 #[cfg(test)]
 mod tests {
-    extern crate xattr;
-
     use tempfile::{tempdir, TempDir};
 
     use std::fs;


### PR DESCRIPTION
rust-2018-idioms is used because there isn't a rust-2021-idioms lint yet.
See https://doc.rust-lang.org/rustc/lints/groups.html to see which lints are enabled by rust-2018-idioms and rust-2021-compatibility.

What I did was change the edition to 2018 for all the packages and then ran:
```
cargo fix --allow-dirty --edition-idioms
```
which fixed some of the issues, and I've fixed the rest manually.