### PR TITLE
Remove unused host dependencies in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,5 +17,5 @@ jobs:
                 components: clippy, rustfmt
             - name: install dependencies
               run: |
-                sudo apt-get install libfuse-dev libzstd-dev libxxhash-dev skopeo umoci capnproto
+                sudo apt-get install skopeo umoci capnproto
             - run: make lint check


### PR DESCRIPTION
The dependency for libfuse-dev was removed in
3bfbbb2615d9356da879a50c2a21c480b2167fd9. libzstd-dev and libxxhash-dev were used by the zstd-seekable library which we no longer use.