### PR TITLE
Change major/minor format into version format

### DIFF
--- a/doc/metadata.md
+++ b/doc/metadata.md
@@ -90,8 +90,7 @@
 
             // chr
             struct {
-                dev_t major;
-                dev_t minor;
+                dev_t version;
             },
 
             // dir
@@ -102,8 +101,7 @@
             // blk; do we even want these? seems like maybe not since they're
             // system specific.
             struct {
-                dev_t major;
-                dev_t minor;
+                version;
             },
 
             // reg

--- a/puzzlefs-lib/src/extractor.rs
+++ b/puzzlefs-lib/src/extractor.rs
@@ -97,11 +97,11 @@ pub fn extract_rootfs(oci_dir: &str, tag: &str, extract_dir: &str) -> anyhow::Re
             InodeMode::Fifo => {
                 mkfifo(&path, Mode::S_IRWXU)?;
             }
-            InodeMode::Chr { major, minor } => {
-                mknod(&path, SFlag::S_IFCHR, Mode::S_IRWXU, makedev(major, minor))?;
+            InodeMode::Chr { version } => {
+                mknod(&path, SFlag::S_IFCHR, Mode::S_IRWXU, makedev(version, 0))?;
             }
-            InodeMode::Blk { major, minor } => {
-                mknod(&path, SFlag::S_IFBLK, Mode::S_IRWXU, makedev(major, minor))?;
+            InodeMode::Blk { version } => {
+                mknod(&path, SFlag::S_IFBLK, Mode::S_IRWXU, makedev(version, 0))?;
             }
             InodeMode::Lnk => {
                 let target = dir_entry.inode.symlink_target()?;

--- a/puzzlefs-lib/src/format/metadata.capnp
+++ b/puzzlefs-lib/src/format/metadata.capnp
@@ -1,8 +1,7 @@
 @0x84ae5e6e88b7cbb7;
 
 struct Chr {
-    major@0: UInt64;
-    minor@1: UInt64;
+    version@0: UInt64;
 }
 
 struct DirEntry {
@@ -16,8 +15,7 @@ struct Dir {
 }
 
 struct Blk {
-    major@0: UInt64;
-    minor@1: UInt64;
+    version@0: UInt64;
 }
 
 struct FileChunk {


### PR DESCRIPTION
Addresses Issue here: https://github.com/project-machine/puzzlefs/issues/10

This PR replaces major/minor versionining to be a single version variable. u64 should be plenty for both rather than using 2 u64. 