### PR TITLE
Lxc integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "puzzlefs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "puzzlefs-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cap-std",

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ tree /tmp/example-rootfs
 
 Then run:
 ```
-$ cargo run --release -- build /tmp/example-rootfs /tmp/puzzlefs-image puzzlefs_example
+$ cargo run --release -- build /tmp/example-rootfs /tmp/puzzlefs-image:puzzlefs_example
 puzzlefs image manifest digest: 9ac9abc098870c55cc61431dae8635806273d8f61274d34bec062560e79dc2f5
 ```
 This builds a puzzlefs image with the above root filesystem in `/tmp/puzzlefs-image`, with the tag `puzzlefs_example`.
@@ -107,13 +107,13 @@ It also outputs the image's manifest digest, which is useful for verifying the i
 For additional build options, run `puzzlefs build -h`.
 
 ### Mounting a puzzlefs image
-To mount the above puzlefs image, first we need to create a mountpoint:
+To mount the above puzzlefs image, first we need to create a mountpoint:
 ```
 mkdir /tmp/mounted-image
 ```
 Then run `puzzlefs mount` with the location of the puzzlefs image, the image tag and the mountpoint:
 ```
-$ cargo run --release -- mount /tmp/puzzlefs-image puzzlefs_example /tmp/mounted-image
+$ cargo run --release -- mount /tmp/puzzlefs-image:puzzlefs_example /tmp/mounted-image
 ```
 
 If everything was successful, you will see a `fuse` entry in the output of `mount`:
@@ -145,7 +145,7 @@ For additional mount options, run `cargo run -- mount -h`.
 ### Mounting with fs-verity enabled
 If you want to mount the filesystem with `fs-verity` authenticity protection, first enable `fs-verity` by running:
 ```
-$ cargo run --release -- enable-fs-verity /tmp/puzzlefs-image puzzlefs_example 9ac9abc098870c55cc61431dae8635806273d8f61274d34bec062560e79dc2f5
+$ cargo run --release -- enable-fs-verity /tmp/puzzlefs-image:puzzlefs_example 9ac9abc098870c55cc61431dae8635806273d8f61274d34bec062560e79dc2f5
 ```
 This makes the data and metadata files readonly. Any reads of corrupted data will fail.
 

--- a/exe/Cargo.toml
+++ b/exe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puzzlefs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tycho Andersen <tycho@tycho.pizza>", "Ariel Miculas <amiculas@cisco.com>"]
 description = """
 PuzzleFS is a next-generation container filesystem.
@@ -24,7 +24,7 @@ log = "0.4.17"
 env_logger = "0.9.3"
 syslog = "6.0.1"
 os_pipe = "1.1.2"
-puzzlefs-lib = { path = "../puzzlefs-lib", version = "0.1.0" }
+puzzlefs-lib = { path = "../puzzlefs-lib", version = "0.2.0" }
 hex = "0.4.3"
 
 [dev-dependencies]

--- a/exe/tests/extract.rs
+++ b/exe/tests/extract.rs
@@ -13,18 +13,18 @@ fn build_and_extract_is_noop() -> anyhow::Result<()> {
 
     // TODO: figure out a better way to do all this osstr stuff...
     let oci = dir.path().join("oci");
+    let mut oci_arg = oci.into_os_string();
+    oci_arg.push(OsStr::new(":test"));
     puzzlefs([
         OsStr::new("build"),
         ubuntu_rootfs.as_ref(),
-        oci.as_ref(),
-        OsStr::new("test"),
+        oci_arg.as_ref(),
     ])?;
 
     let extracted = dir.path().join("extracted");
     puzzlefs([
         OsStr::new("extract"),
-        oci.as_os_str(),
-        OsStr::new("test"),
+        oci_arg.as_os_str(),
         extracted.as_os_str(),
     ])?;
     assert!(!dir_diff::is_different(ubuntu_rootfs, extracted).unwrap());

--- a/exe/tests/verity.rs
+++ b/exe/tests/verity.rs
@@ -81,12 +81,9 @@ fn test_fs_verity() -> anyhow::Result<()> {
     let rootfs = Path::new("../puzzlefs-lib/src/builder/test/test-1/");
 
     let oci = mount_path.join("oci");
-    let output = puzzlefs([
-        OsStr::new("build"),
-        rootfs.as_ref(),
-        oci.as_ref(),
-        OsStr::new("test"),
-    ])?;
+    let mut oci_arg = oci.clone().into_os_string();
+    oci_arg.push(OsStr::new(":test"));
+    let output = puzzlefs([OsStr::new("build"), rootfs.as_ref(), oci_arg.as_ref()])?;
 
     let tokens = output.split_whitespace().collect::<Vec<_>>();
 
@@ -101,8 +98,7 @@ fn test_fs_verity() -> anyhow::Result<()> {
 
     puzzlefs([
         OsStr::new("enable-fs-verity"),
-        oci.as_ref(),
-        OsStr::new("test"),
+        oci_arg.as_ref(),
         OsStr::new(digest),
     ])?;
 
@@ -118,8 +114,7 @@ fn test_fs_verity() -> anyhow::Result<()> {
         OsStr::new("-f"),
         OsStr::new("-d"),
         OsStr::new(RANDOM_DIGEST),
-        oci.as_ref(),
-        OsStr::new("test"),
+        oci_arg.as_ref(),
         OsStr::new(&puzzlefs_mountpoint),
     ]);
 
@@ -133,8 +128,7 @@ fn test_fs_verity() -> anyhow::Result<()> {
         OsStr::new("mount"),
         OsStr::new("-d"),
         OsStr::new(digest),
-        oci.as_ref(),
-        OsStr::new("test"),
+        oci_arg.as_ref(),
         OsStr::new(&puzzlefs_mountpoint),
     ])?;
 

--- a/puzzlefs-lib/Cargo.toml
+++ b/puzzlefs-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "puzzlefs-lib"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tycho Andersen <tycho@tycho.pizza>", "Ariel Miculas <amiculas@cisco.com>"]
 description = """
 Build, mount and extract PuzzleFS images.

--- a/puzzlefs-lib/src/oci.rs
+++ b/puzzlefs-lib/src/oci.rs
@@ -121,7 +121,16 @@ impl Image {
         } else {
             self.0.dir.write(&path, final_data)?;
         }
-        image_manifest.layers_mut().push(descriptor.clone());
+
+        // Let's make the PuzzleFS image rootfs the first layer so it's easy to find
+        // The LXC oci template also looks at the first layer in the array to identify the image
+        // type (see getlayermediatype):
+        // https://github.com/lxc/lxc/commit/1a2da75b6e8431f3530ebd3f75442d3bd5eec5e2
+        if media_type.name() == PUZZLEFS_ROOTFS {
+            image_manifest.layers_mut().insert(0, descriptor.clone());
+        } else {
+            image_manifest.layers_mut().push(descriptor.clone());
+        }
         Ok((descriptor, fs_verity_digest, compressed_blob))
     }
 


### PR DESCRIPTION
Prepare PuzzleFS for LXC integration:
* Store the empty descriptor in blobs/sha256 so that skopeo can copy PuzzleFS images
* Move the PuzzleFS Image Rootfs at the beginning of the layers array in the Image Manifest for faster lookup and for media type identification by the OCI template in LXC
* Pass the oci_dir and tag in the format <oci_dir>:<tag> so it's compatible with the mount helper defined in the OCI template in LXC
* Finally, update the puzzlefs version to 0.2.0