### PR TITLE
Switch to zeekstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -125,15 +125,6 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -735,12 +726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,16 +975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
 ]
 
 [[package]]
@@ -1304,8 +1279,7 @@ dependencies = [
  "thiserror 1.0.63",
  "walkdir",
  "xattr",
- "zstd",
- "zstd-seekable",
+ "zeekstd",
 ]
 
 [[package]]
@@ -1637,15 +1611,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]
@@ -1982,6 +1947,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeekstd"
+version = "0.4.0"
+source = "git+https://github.com/rorosen/zeekstd#a0ee112d570f6e160f615b464e546f2979cb0d0a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,44 +1976,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
-name = "zstd-seekable"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574a117c5cdb88d1f13381ee3a19a6a45fb6ca0c98436d3a95df852b7ca6c3c2"
-dependencies = [
- "bincode",
- "cc",
- "libc",
- "pkg-config",
- "serde",
- "serde_derive",
- "thiserror 1.0.63",
- "threadpool",
-]
-
-[[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/puzzlefs-lib/Cargo.toml
+++ b/puzzlefs-lib/Cargo.toml
@@ -23,7 +23,6 @@ anyhow = "1.0.75"
 nix = { version = "0.27.1", features = ["user", "fs"] }
 xattr = "1.3.0"
 log = "0.4.17"
-zstd = "0.13.1"
 serde = { version = "1.0.27", features = [ "derive" ] }
 serde_json = "1.0.106"
 thiserror = "1.0.46"
@@ -39,7 +38,7 @@ fuser = {version = "0.14", default-features = false}
 os_pipe = "1.1.2"
 tempfile = "3.10"
 openat = "0.1.21"
-zstd-seekable = "0.1.23"
+zeekstd = {git = "https://github.com/rorosen/zeekstd"}
 ocidir = "0.4.0"
 cap-std = "3.2.0"
 

--- a/puzzlefs-lib/src/builder.rs
+++ b/puzzlefs-lib/src/builder.rs
@@ -552,7 +552,7 @@ pub mod tests {
         // there should be a blob that matches the hash of the test data, since it all gets input
         // as one chunk and there's only one file
         const FILE_DIGEST: &str =
-            "3eee1082ab3babf6c1595f1069d11ebc2a60135890a11e402e017ddd831a220d";
+            "d568d1505905ee36e66ef6f94f544a50f52c6a63574048da0cf351b8235ff42b";
 
         let md = image
             .0

--- a/puzzlefs-lib/src/compression/zstd_seekable_wrapper.rs
+++ b/puzzlefs-lib/src/compression/zstd_seekable_wrapper.rs
@@ -1,8 +1,7 @@
-use std::cmp::min;
 use std::io;
 use std::io::{Read, Seek, Write};
 
-use zstd_seekable::{CStream, Seekable, SeekableCStream};
+use zeekstd::{Decoder, EncodeOptions, Encoder, FrameSizePolicy};
 
 use crate::compression::{Compression, Compressor, Decompressor};
 
@@ -14,56 +13,36 @@ use crate::compression::{Compression, Compressor, Decompressor};
 // Another consideration is the average chunk size from FastCDC: if we make this the same as the
 // chunk size, there's no real point in using seekable compression at all, at least for files. It's
 // also possible that we want different frame sizes for metadata blobs and file content.
-const FRAME_SIZE: usize = 4096;
-const COMPRESSION_LEVEL: usize = 3;
+const FRAME_SIZE: u32 = 4096;
+const COMPRESSION_LEVEL: i32 = 3;
 
 fn err_to_io<E: 'static + std::error::Error + Send + Sync>(e: E) -> io::Error {
     io::Error::other(e)
 }
 
-pub struct ZstdCompressor<W> {
-    f: W,
-    stream: SeekableCStream,
-    buf: Vec<u8>,
+pub struct ZstdCompressor<'a, W> {
+    encoder: Encoder<'a, W>,
 }
 
-impl<W: Write> Compressor for ZstdCompressor<W> {
-    fn end(mut self: Box<Self>) -> io::Result<()> {
-        // end_stream has to be called multiple times until 0 is returned, see
-        // https://docs.rs/zstd-seekable/0.1.23/src/zstd_seekable/lib.rs.html#224-237 and
-        // https://fossies.org/linux/zstd/contrib/seekable_format/zstd_seekable.h
-        loop {
-            let size = self.stream.end_stream(&mut self.buf).map_err(err_to_io)?;
-            self.f.write_all(&self.buf[0..size])?;
-            if size == 0 {
-                break;
-            }
-        }
+impl<'a, W: Write> Compressor for ZstdCompressor<'a, W> {
+    fn end(self: Box<Self>) -> io::Result<()> {
+        self.encoder.finish().map_err(err_to_io)?;
         Ok(())
     }
 }
 
-impl<W: Write> Write for ZstdCompressor<W> {
+impl<'a, W: Write> Write for ZstdCompressor<'a, W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // TODO: we could try to consume all the input, but for now we just consume a single block
-        let (out_pos, in_pos) = self
-            .stream
-            .compress(&mut self.buf, buf)
-            .map_err(err_to_io)?;
-        self.f.write_all(&self.buf[0..out_pos])?;
-        Ok(in_pos)
+        self.encoder.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        // we could self.stream.flush(), but that adversely affects compression ratio... let's
-        // cheat for now.
-        Ok(())
+        self.encoder.flush()
     }
 }
 
 pub struct ZstdDecompressor<'a, R: Read + Seek> {
-    stream: Seekable<'a, R>,
-    offset: u64,
+    decoder: Decoder<'a, R>,
     uncompressed_length: u64,
 }
 
@@ -75,40 +54,13 @@ impl<R: Seek + Read> Decompressor for ZstdDecompressor<'_, R> {
 
 impl<R: Seek + Read> Seek for ZstdDecompressor<'_, R> {
     fn seek(&mut self, offset: io::SeekFrom) -> io::Result<u64> {
-        match offset {
-            io::SeekFrom::Start(s) => {
-                self.offset = s;
-            }
-            io::SeekFrom::End(e) => {
-                if e > 0 {
-                    return Err(io::Error::other("zstd seek past end"));
-                }
-                self.offset = self.uncompressed_length - u64::try_from(-e).map_err(err_to_io)?;
-            }
-            io::SeekFrom::Current(c) => {
-                if c > 0 {
-                    self.offset += u64::try_from(c).map_err(err_to_io)?;
-                } else {
-                    self.offset -= u64::try_from(-c).map_err(err_to_io)?;
-                }
-            }
-        }
-        Ok(self.offset)
+        self.decoder.seek(offset)
     }
 }
 
 impl<R: Seek + Read> Read for ZstdDecompressor<'_, R> {
     fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
-        // decompress() gets angry (ZSTD("Corrupted block detected")) if you pass it a buffer
-        // longer than the uncompressable data, so let's be careful to truncate the buffer if it
-        // would make zstd angry. maybe soon they'll implement a real read() API :)
-        let end = min(out.len(), (self.uncompressed_length - self.offset) as usize);
-        let size = self
-            .stream
-            .decompress(&mut out[0..end], self.offset)
-            .map_err(err_to_io)?;
-        self.offset += size as u64;
-        Ok(size)
+        self.decoder.read(out)
     }
 }
 
@@ -118,26 +70,30 @@ impl Compression for Zstd {
     fn compress<'a, W: Write + 'a>(dest: W) -> io::Result<Box<dyn Compressor + 'a>> {
         // a "pretty high" compression level, since decompression should be nearly the same no
         // matter what compression level. Maybe we should turn this to 22 or whatever the max is...
-        let stream = SeekableCStream::new(COMPRESSION_LEVEL, FRAME_SIZE).map_err(err_to_io)?;
-        Ok(Box::new(ZstdCompressor {
-            f: dest,
-            stream,
-            buf: vec![0_u8; CStream::out_size()],
-        }))
+        let encoder = EncodeOptions::new()
+            .compression_level(COMPRESSION_LEVEL)
+            .frame_size_policy(FrameSizePolicy::Uncompressed(FRAME_SIZE))
+            .into_encoder(dest)
+            .map_err(err_to_io)?;
+        Ok(Box::new(ZstdCompressor { encoder }))
     }
 
     fn decompress<'a, R: Read + Seek + 'a>(source: R) -> io::Result<Box<dyn Decompressor + 'a>> {
-        let stream = Seekable::init(Box::new(source)).map_err(err_to_io)?;
+        // let decoder = Seekable::init(Box::new(source)).map_err(err_to_io)?;
+        let decoder = Decoder::new(source).map_err(err_to_io)?;
+        let seek_table = decoder.seek_table();
 
         // zstd-seekable doesn't like it when we pass a buffer past the end of the uncompressed
         // stream, so let's figure out the size of the uncompressed file so we can implement
         // ::read() in a reasonable way. This also lets us implement SeekFrom::End.
-        let uncompressed_length = (0..stream.get_num_frames())
-            .map(|i| stream.get_frame_decompressed_size(i) as u64)
+        let uncompressed_length = (0..seek_table.num_frames())
+            .map(|i| seek_table.frame_size_decomp(i))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(err_to_io)?
+            .iter()
             .sum();
         Ok(Box::new(ZstdDecompressor {
-            stream,
-            offset: 0,
+            decoder,
             uncompressed_length,
         }))
     }

--- a/puzzlefs-lib/src/compression/zstd_seekable_wrapper.rs
+++ b/puzzlefs-lib/src/compression/zstd_seekable_wrapper.rs
@@ -86,12 +86,7 @@ impl Compression for Zstd {
         // zstd-seekable doesn't like it when we pass a buffer past the end of the uncompressed
         // stream, so let's figure out the size of the uncompressed file so we can implement
         // ::read() in a reasonable way. This also lets us implement SeekFrom::End.
-        let uncompressed_length = (0..seek_table.num_frames())
-            .map(|i| seek_table.frame_size_decomp(i))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(err_to_io)?
-            .iter()
-            .sum();
+        let uncompressed_length = seek_table.size_decomp();
         Ok(Box::new(ZstdDecompressor {
             decoder,
             uncompressed_length,


### PR DESCRIPTION
Kudos to @rorosen for creating the awesome zeekstd project and for the quick implementation of the [decompression from byte offsets](https://github.com/rorosen/zeekstd/issues/2)

There is a small difference in the compressed output from the what the previous zstd-seekable crate generated, although the frames look the same under `zeekstd list --detail` output (see the latest commit).